### PR TITLE
iBeacon Example is confusin

### DIFF
--- a/examples/ibeacon-scan/index.html
+++ b/examples/ibeacon-scan/index.html
@@ -38,6 +38,9 @@
 	</header>
 
 	<h1>iBeacon Scan</h1>
+	<p>Please note that to identify iBeacons you will have to add the uuid's you
+	are looking for to the regions dictionary in app.js of the iBeacon example.
+	</p>
 
 	<ul id="found-beacons" class="dynamic"></ul>
 


### PR DESCRIPTION
# Problem
The iBeacon example included by default in the example pack scans based on a known list of ibeacons. This is not indicated to the user and as such the when the example is run displays nothing. 

# Solution 
This pull request adds simple instructions telling the user to add the ibeacons they want to scan for to the dictionary in the app.js file. 

This is not an ideal solution, but it is an effective short term patch.

# Future patch:
Ideally the app would scan for all iBeacons in range (using the apple 0x004C identifier to exclude everything else) and report on them, not requiring a hardcoded list. 