### PR TITLE
iBeacon example is confusing

### DIFF
--- a/examples/ibeacon-scan/app.js
+++ b/examples/ibeacon-scan/app.js
@@ -3,7 +3,7 @@ var app = (function()
 	// Application object.
 	var app = {};
 
-	// Specify your beacon UUIDs here.
+	// Specify your beacon 128bit UUIDs here.
 	var regions =
 	[
 		// Estimote Beacon factory UUID.
@@ -12,6 +12,7 @@ var app = (function()
 		{uuid:'F7826DA6-4FA2-4E98-8024-BC5B71E0893E'},
 		{uuid:'8DEEFBB9-F738-4297-8040-96668BB44281'},
 		{uuid:'A0B13730-3A9A-11E3-AA6E-0800200C9A66'},
+		{uuid:'E20A39F4-73F5-4BC4-A12F-17D1AD07A961'},
 		{uuid:'A4950001-C5B1-4B44-B512-1370F02D74DE'}
 	];
 
@@ -130,6 +131,7 @@ var app = (function()
 					+ '</li>'
 				);
 
+				$('#warning').remove();
 				$('#found-beacons').append(element);
 			}
 		});

--- a/examples/ibeacon-scan/index.html
+++ b/examples/ibeacon-scan/index.html
@@ -38,10 +38,9 @@
 	</header>
 
 	<h1>iBeacon Scan</h1>
-	<p>Please note that to identify iBeacons you will have to add the uuid's you
+	<p id="warning">To detect iBeacons you will have to add the 128bit UUID's you
 	are looking for to the regions dictionary in app.js of the iBeacon example.
 	</p>
-
 	<ul id="found-beacons" class="dynamic"></ul>
 
 </body>

--- a/examples/ibeacon-scan/index.html
+++ b/examples/ibeacon-scan/index.html
@@ -38,6 +38,9 @@
 	</header>
 
 	<h1>iBeacon Scan</h1>
+	<p>Please note that to identify iBeacons you will have to add the uuid's you
+	are looking for to the regions dictionary in app.js of the iBeacon example.
+	</p>
 
 	<ul id="found-beacons" class="dynamic"></ul>
 


### PR DESCRIPTION
# Problem
The iBeacon example does not indicate that there need to be hard coded UUID's in the example app.

# Fix
Add warning message that dissapears when first iBeacon is detected

# Future
detect if uuid is iBeacon (by 0x004C mask) and then display information on beacon, no need  for a hard coded list.