### PR TITLE
Adding conversion function for advertising data to util.js

### DIFF
--- a/resources/libs/evothings/util/util.js
+++ b/resources/libs/evothings/util/util.js
@@ -79,6 +79,20 @@ evothings.util = (function()
 		return taBytes;
 	}
 
+	// Converts from base64 Ascii encoded string to hex encoded string
+	// useful to convert advertisementData.kCBAdvDataManufacturerData
+	// back to the raw hex values. Useful for microcontrollers and low level
+	// pairings on things like iBeacon
+	funs.toHexRawData = function(string){
+		byteArray = evothings.util.base64DecToArr(string)
+		var srs = ''
+		for(var i=0; i<byteArray.length; i++) {
+			srs += evothings.util.toHexString(byteArray[i], 1);
+		}
+		//console.log("scanRecord: "+srs);
+		return srs;
+	}
+
 	// Returns the integer i in hexadecimal string form,
 	// with leading zeroes, such that
 	// the resulting string is at least byteCount*2 characters long.


### PR DESCRIPTION
# The Problem
the raw data in the advertisementData is by default returned in a character string, this garbles the data when it is not meant to be read as character data. (think for things like iBeacon which encode a bunch of hex data into the advertisementData.manufacturerData section)

# The Solution
added a function to convert from character string back to a hex string for easy comparison.

# example : iBeacons
For ibeacons the microcontroller code would look something like the following:
```C++
    /**
     * The Beacon payload (encapsulated within the MSD advertising data structure)
     * has the following composition:
     * 128-Bit UUID = E2 0A 39 F4 73 F5 4B C4 A1 2F 17 D1 AD 07 A9 61
     * Major/Minor  = 0000 / 0000
     * Tx Power     = C8 (-56dB)
     */
    const static uint8_t iBeaconPayload[] = {
        0x4C, 0x00, // Company identifier code (0x004C == Apple)
        0x02,       // ID
        0x15,       // length of the remaining payload
        0xE2, 0x0A, 0x39, 0xF4, 0x73, 0xF5, 0x4B, 0xC4, // location UUID
        0xA1, 0x2F, 0x17, 0xD1, 0xAD, 0x07, 0xA9, 0x61,
        0xDE, 0xAD, // the major value to differentiate a location
        0xBE, 0xEF, // the minor value to differentiate a location
        0xC8        // 2's complement of the Tx power (-56dB)
    };
```
The evothings app would then do something like the following
```JavaScript
// extract the hex string
rawData = evothings.util.toHexRawData(device.advertisementData.kCBAdvDataManufacturerData)
// print the hext string for comparison to microcontroller code
console.log(rawData)
```
the above code would return 
```shell
LOG: 4c000215e20a39f473f54bc4a12f17d1ad07a961deadbeefc8
```

which is really easy to compare against the microcontroller code. 

This module also will open up the possibility to create a better iBeacon example that scans for BLE devices with manufacturing data with the first 2 bytes = "0x4C00" instead of using a whitelist like is currently done. 