### PR TITLE
Fixed #170, viewport growing on iOS9, cordova-accelerator example

### DIFF
--- a/examples/cordova-accelerometer/index.html
+++ b/examples/cordova-accelerometer/index.html
@@ -7,8 +7,8 @@ Demonstration of the Cordova Accelerometer API.
 <head>
 	<meta charset="utf-8" />
 	<meta name="format-detection" content="telephone=no" />
-	<meta name="viewport" content="width=device-width, user-scalable=no
-		initial-scale=1.0, minimum-scale=1.0, maximum-scale=1.0" />
+	<meta name="viewport" content="width=device-width, user-scalable=no,
+		shrink-to-fit=no, initial-scale=1.0, minimum-scale=1.0, maximum-scale=1.0" />
 
 	<title>Cordova Accelerometer</title>
 


### PR DESCRIPTION
Tested on iOS 9.1, 7.1.1, 8.1.3. 