### PR TITLE
Use onboard LED

### DIFF
--- a/examples/esp8266/esp8266/esp8266.ino
+++ b/examples/esp8266/esp8266/esp8266.ino
@@ -2,7 +2,7 @@
 
 const char* ssid = "your_wifi_network_name";
 const char* password = "your_wifi_network_password";
-const int ledPin = 2;
+const int ledPin = 16; // onboard LED
 WiFiServer server(1337);
 
 void printWiFiStatus();


### PR DESCRIPTION
Use onboard LED pin which is pin 16. Eliminate the need for extra hardware and connect to external LED.